### PR TITLE
make mode indicators 1 letter, like in upstream busybox vi

### DIFF
--- a/vi.c
+++ b/vi.c
@@ -216,7 +216,7 @@ enum {  //cmd_modes
 };
 
 static const char *cmd_mode_indicator[] =
-	{"COMMAND", "INSERT", "REPLACE", "?!?" };
+	{"-", "I", "R", "?" };
 
 /* vi.c expects chars to be unsigned. */
 /* busybox build system provides that, but it's better */


### PR DESCRIPTION
mostly personal preference, but i think it looks nicer when it is one letter for mode indicators.